### PR TITLE
Enable NTLMv2 authentication

### DIFF
--- a/root/etc/e-smith/templates/etc/samba/smb.conf/10global
+++ b/root/etc/e-smith/templates/etc/samba/smb.conf/10global
@@ -51,6 +51,9 @@ wins server = { $smb{ServerRole} eq 'PDC' ? '' : $winsServerIp }
 remote announce = { $smb{ServerRole} eq 'PDC' ? '' :  $winsServerIp }
 remote browse sync = { $smb{ServerRole} eq 'PDC' ? '' : $winsServerIp }
 
+; Enable NTLMv2 Authentication
+client ntlmv2 auth = yes
+
 ; LDAP database backend configuration
 passdb backend = ldapsam:ldap://127.0.0.1
 ldapsam:trusted = yes


### PR DESCRIPTION
Enable NTLMv2 authentication to allow Samba to work with Windows networks where NTLMv2 is the only enabled authentication protocol.
See [Enhancement #3409](http://dev.nethserver.org/issues/3409) on dev.nethserver.org