### PR TITLE
Remove hosts allow

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -81,10 +81,3 @@ foreach (qw(ibay-create ibay-modify ibay-delete)) {
         smb reload
     ));
 }
-
-#
-# interface-update
-#
-event_services('interface-update', qw(
-    nmb start
-));

--- a/createlinks
+++ b/createlinks
@@ -44,18 +44,6 @@ event_services('nethserver-samba-update', qw(
 ));
 
 
-#--------------------------------------------------
-# actions for trusted-networks-modify event
-#--------------------------------------------------
-event_templates('trusted-networks-modify', qw(
-    /etc/samba/smb.conf
-));
-
-event_services('trusted-networks-modify', qw(
-   smb restart
-   nmb restart
-));
-
 #
 # migration-import event (refs #1657)
 #

--- a/nethserver-samba.spec
+++ b/nethserver-samba.spec
@@ -11,12 +11,8 @@ Requires: samba
 Requires: tdb-tools
 Requires: nethserver-ibays
 Requires: sssd-libwbclient
-Requires(post): systemd
-Requires(preun): systemd
-Requires(postun): systemd
 
 BuildRequires: nethserver-devtools
-BuildRequires:  systemd
 
 %description
 * Provides SMB shares as Shared folders (ibays)
@@ -37,15 +33,6 @@ rm -rf %{buildroot}
 %{genfilelist} %{buildroot} > %{name}-%{version}-filelist
 
 mkdir -p %{buildroot}/%{_nsstatedir}/print_driver
-
-%post
-%systemd_post nmb.service
-
-%preun
-%systemd_preun nmb.service
-
-%postun
-%systemd_postun
 
 %files -f %{name}-%{version}-filelist
 %doc COPYING

--- a/root/etc/e-smith/templates/etc/samba/smb.conf/00template_vars
+++ b/root/etc/e-smith/templates/etc/samba/smb.conf/00template_vars
@@ -8,7 +8,6 @@
 
     $baseDir = '/var/lib/nethserver';
 
-    @hostsAllow = $ndb->local_access_spec;
     @netbiosAliasList = split(',', $smb{NetbiosAliasList});
 
     '';

--- a/root/etc/e-smith/templates/etc/samba/smb.conf/10global
+++ b/root/etc/e-smith/templates/etc/samba/smb.conf/10global
@@ -5,8 +5,6 @@ log file = /var/log/samba/log.%m
 # maximum size of 50KB per log file, then rotate:
 max log size = 50
 
-hosts allow = { join(' ', @hostsAllow) }
-
 # Idle time before disconnecting the client
 deadtime = { int($smb{DeadTime}) }
 

--- a/root/etc/systemd/system/nmb.service.d/override.conf
+++ b/root/etc/systemd/system/nmb.service.d/override.conf
@@ -1,2 +1,0 @@
-[Unit]
-ConditionPathExists=!/var/run/.nethserver-fixnetwork


### PR DESCRIPTION
We can simplify our smbd and nmbd configuration, by relying on firewall configuration to limit access to the services from green zone only.

This PR requires #20 to be merged.

If Samba daemons are bound to the wildcard address, also they should not need a restart/reload due to config file changes.

NethServer/dev#5319