### PR TITLE
ACL: do not enable acl and user_xattr on XFS

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-samba-conf
+++ b/root/etc/e-smith/events/actions/nethserver-samba-conf
@@ -39,6 +39,28 @@ my $confdb = esmith::ConfigDB->open() || die("Could not open ConfigDB");
 my $fstab = $confdb->get('fstab') or return "";
 
 my $prop = $fstab->prop('/') || 'defaults';
+
+# Skip XFS filesystems and fix existing ones
+my @filesystems=`lsblk -ln -o MOUNTPOINT,FSTYPE`;
+foreach (@filesystems) {
+    chomp;
+    my @tmp = split(/\s+/,$_);
+    if ($tmp[0] eq '/' && ($tmp[1] eq 'xfs' || $tmp[1] eq 'btrfs')) {
+        # Fix existing FS
+        my @options;
+        foreach my $opt (split(',',$prop)) {
+            if ($opt eq 'user_xattr' || $opt eq 'acl') {
+                next;
+            } else {
+                push(@options, $opt);
+            }
+        }
+        $fstab->set_prop('/',join(',',@options));
+
+        exit (! esmith::event::event_signal('fstab-update'));
+    }
+}
+
 $prop .= ",acl" unless ($prop =~ /acl/);
 $prop .= ",user_xattr" unless ($prop =~ /user_xattr/);
 $fstab->set_prop('/',$prop);


### PR DESCRIPTION
XFS already has it enabled by default.
If options are present, kernel 3.10.0-693 will mount the FS
in read-only mode.

Props for exiting FS are fixed inside the action to avoid
iterations on lsblk inside db migration fragments.

NethServer/dev#5349