### PR TITLE
 Fix samba shares access denied

### DIFF
--- a/nethserver-samba.spec
+++ b/nethserver-samba.spec
@@ -10,6 +10,8 @@ BuildArch: noarch
 URL: %{url_prefix}/%{name} 
 Provides: nethserver-ibays
 Obsoletes: nethserver-ibays
+Obsoletes: sssd-libwbclient
+Conflicts: sssd-libwbclient
 
 Requires: samba
 Requires: tdb-tools

--- a/root/etc/e-smith/events/actions/nethserver-samba-libwbclient
+++ b/root/etc/e-smith/events/actions/nethserver-samba-libwbclient
@@ -21,10 +21,12 @@
 #
 
 #
-# Reset libwbclient and CIFS to default Samba winbind library (#5647)
+# Reset libwbclient and CIFS to default Samba winbind library (#5647, #5801)
 #
 
-alternatives --set libwbclient.so.0.14-64 /usr/lib64/samba/wbclient/libwbclient.so.0.14 || :
+alternatives --install /usr/lib64/libwbclient.so.0.14 libwbclient.so.0.14-64 /usr/lib64/samba/wbclient/libwbclient.so.0.14 10
+alternatives --auto libwbclient.so.0.14-64 # revert to auto (default)
+ldconfig # always run ldconfig after alternatives --install
 echo "[NOTICE] $(alternatives --display libwbclient.so.0.14-64)"
 
 alternatives  --set cifs-idmap-plugin /usr/lib64/cifs-utils/idmapwb.so


### PR DESCRIPTION
- Uninstall sssd-libwbclient RPM
- Force the `alternatives` symlinks maintainer to reset libwbclient library to default upstream configuration

NethServer/dev#5801