### PR TITLE
Enable idmapwb.so only if available

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-samba-libwbclient
+++ b/root/etc/e-smith/events/actions/nethserver-samba-libwbclient
@@ -27,5 +27,7 @@
 alternatives --set libwbclient.so.0.14-64 /usr/lib64/samba/wbclient/libwbclient.so.0.14 || :
 echo "[NOTICE] $(alternatives --display libwbclient.so.0.14-64)"
 
-alternatives  --set cifs-idmap-plugin /usr/lib64/cifs-utils/idmapwb.so
-echo "[NOTICE] $(alternatives --display cifs-idmap-plugin)"
+if [[ -e /usr/lib64/cifs-utils/idmapwb.so ]]; then
+    alternatives  --set cifs-idmap-plugin /usr/lib64/cifs-utils/idmapwb.so
+    echo "[NOTICE] $(alternatives --display cifs-idmap-plugin)"
+fi


### PR DESCRIPTION
Check for library existence before running `alternatives` to avoid warning messages in logs.

When winbind runs locally we set the cifs library to send idmap request to it. But the cifs library is pulled in by the nethserver-backup-data RPM and in some cases it could be missing.

Bundle with nethserver/dev#5801
