### PR TITLE
config: enable admin access for migrated ibays

### DIFF
--- a/root/etc/e-smith/templates/etc/samba/smb.conf/ibay-migration/30share_adm
+++ b/root/etc/e-smith/templates/etc/samba/smb.conf/ibay-migration/30share_adm
@@ -1,0 +1,9 @@
+;
+; 30share_adm
+;
+{
+    $OUT = '; administrative access is disabled';
+    if($smb{ShareAdmStatus} eq 'enabled') {
+        $OUT = 'admin users = "@domain admins"';
+    }
+}


### PR DESCRIPTION
Since the ShareAdmStatus is a global option, it should
be available also for migrated ibays