### PR TITLE
Fix Reset of default ACL entries

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-ibays-copy-permissions
+++ b/root/etc/e-smith/events/actions/nethserver-ibays-copy-permissions
@@ -29,7 +29,7 @@ if [[ ! -d "${ibayPath}" ]]; then
     exit 1
 fi
 
-getfacl "${ibayPath}" | sed '/^[^#]/ s/x$/X/' | setfacl  -R --set-file=- "${ibayPath}"
+getfacl "${ibayPath}" | sed '/^[^#]/ s/x$/X/' | setfacl  -R --remove-default --set-file=- "${ibayPath}"
 if [[ $? != 0 ]]; then
     errors=1
 fi


### PR DESCRIPTION
If the base ACL does not contain any default entry, default entries from subdirs are not removed.

From `setfacl` man page:

```
       -k, --remove-default
           Remove the Default ACL. If no Default ACL exists, no warnings are issued.
```


https://github.com/NethServer/dev/issues/6406